### PR TITLE
Fix mysql dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,9 +9,9 @@ PLT_APPS = kernel stdlib asn1 crypto public_key ssl
 
 # Dependencies
 
-DEPS = poolboy erlang-mysql-driver dh_date
+DEPS = poolboy mysql dh_date
 dep_poolboy = https://github.com/devinus/poolboy.git master
-dep_erlang-mysql-driver = https://github.com/dizzyd/erlang-mysql-driver.git
+dep_mysql = https://github.com/dizzyd/erlang-mysql-driver.git
 dep_dh_date = https://github.com/daleharvey/dh_date.git
 
 include erlang.mk


### PR DESCRIPTION
The application is named mysql (not erlang-mysql-driver)
and current erlang.mk enforces the same name for folder
and for application name as required by OTP.

This allows using erldb as dep properly with current erlang.mk.